### PR TITLE
add gem version # in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ be added or removed at any time.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'hashid-rails'
+gem 'hashid-rails', '~> 1.0'
 ```
 
 And then execute:
@@ -27,7 +27,7 @@ $ bundle
 Or install it yourself as:
 
 ```shell
-$ gem install hashid-rails
+$ gem install hashid-rails -v 1.0
 ```
 
 ## Basic Usage


### PR DESCRIPTION
I installed hashid-rails according to current readme. It installed 0.5 version and not 1.0, which I realized only after getting an undefined method error for **min_hash_length** config option. 

I think the readme should explicitly provide the version number to put in gemfile (at least for now):

gem 'hashid-rails', '~> 1.0'
gem install hashid-rails -v 1.0